### PR TITLE
0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/archive/master.zip
 
 ## Changelog
 
+### [0.5.0] - 2018-03-18
+- Added option for using custom GCODE commands.  When enabled in settings processing of regular M117 messages will stop working. Use the command @SPEAK as replacement to M117.
+
 ### [0.4.0] - 2018-02-23
 - Fixed binding related issues that required saving the settings prior to using the test button.  Now works without saving first.
 
@@ -27,6 +30,7 @@ https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/archive/master.zip
 ### [0.1.0] - 2018-01-17
 - Initial release.
 
+[0.5.0]: https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/tree/0.5.0
 [0.4.0]: https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/tree/0.4.0
 [0.3.0]: https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/tree/0.3.0
 [0.2.0]: https://github.com/jneilliii/OctoPrint-M117SpeechSynthesis/tree/0.2.0

--- a/octoprint_M117SpeechSynthesis/__init__.py
+++ b/octoprint_M117SpeechSynthesis/__init__.py
@@ -8,7 +8,11 @@ class M117SpeechSynthesis(octoprint.plugin.AssetPlugin,
                 octoprint.plugin.SettingsPlugin):
 				
 	def AlertM117(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
-		if gcode and cmd.startswith("M117"):
+		if gcode and cmd.startswith("M117") and not self._settings.get(["useCustomGCODE"]):
+			self._plugin_manager.send_plugin_message(self._identifier, dict(type="speak", msg=re.sub(r'^M117\s?', '', cmd)))
+			return
+			
+		if cmd.startswith("@SPEAK") and self._settings.get(["useCustomGCODE"]):
 			self._plugin_manager.send_plugin_message(self._identifier, dict(type="speak", msg=re.sub(r'^M117\s?', '', cmd)))
 			return
 	
@@ -18,7 +22,7 @@ class M117SpeechSynthesis(octoprint.plugin.AssetPlugin,
 		
 	##-- Settings hooks
 	def get_settings_defaults(self):
-		return dict(enableSpeech=False,speechVoice="",speechVolume=1,speechPitch=1,speechRate=1,speechLanguage="en-US")	
+		return dict(enableSpeech=False,speechVoice="",speechVolume=1,speechPitch=1,speechRate=1,speechLanguage="en-US",useCustomGCODE=False)	
 	
 	##-- Template hooks
 	def get_template_configs(self):

--- a/octoprint_M117SpeechSynthesis/__init__.py
+++ b/octoprint_M117SpeechSynthesis/__init__.py
@@ -13,7 +13,7 @@ class M117SpeechSynthesis(octoprint.plugin.AssetPlugin,
 			return
 			
 		if cmd.startswith("@SPEAK") and self._settings.get(["useCustomGCODE"]):
-			self._plugin_manager.send_plugin_message(self._identifier, dict(type="speak", msg=re.sub(r'^M117\s?', '', cmd)))
+			self._plugin_manager.send_plugin_message(self._identifier, dict(type="speak", msg=re.sub(r'^@SPEAK\s?', '', cmd)))
 			return
 	
 	##-- AssetPlugin hooks

--- a/octoprint_M117SpeechSynthesis/static/js/M117SpeechSynthesis.js
+++ b/octoprint_M117SpeechSynthesis/static/js/M117SpeechSynthesis.js
@@ -12,7 +12,7 @@ $(function() {
 		self.speechLanguage = ko.observable();
 		self.voices = ko.observableArray([{'name':'Select Voice','value':''}]);
 		self.speechEnabledBrowser = ko.observable();
-		self.useCustomGCODE = ko observable();
+		self.useCustomGCODE = ko.observable();
 		
 		if ('speechSynthesis' in window) {
 			// speechSynthesis.onvoiceschanged = function(e) {

--- a/octoprint_M117SpeechSynthesis/static/js/M117SpeechSynthesis.js
+++ b/octoprint_M117SpeechSynthesis/static/js/M117SpeechSynthesis.js
@@ -12,6 +12,7 @@ $(function() {
 		self.speechLanguage = ko.observable();
 		self.voices = ko.observableArray([{'name':'Select Voice','value':''}]);
 		self.speechEnabledBrowser = ko.observable();
+		self.useCustomGCODE = ko observable();
 		
 		if ('speechSynthesis' in window) {
 			// speechSynthesis.onvoiceschanged = function(e) {
@@ -56,6 +57,7 @@ $(function() {
 			self.speechPitch(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechPitch());
 			self.speechRate(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechRate());
 			self.speechLanguage(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechLanguage());
+			self.useCustomGCODE(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.useCustomGCODE());
 			if('speechSynthesis' in window) {
 				self.speechEnabledBrowser(true);
 				// self.loadVoices();
@@ -71,6 +73,7 @@ $(function() {
 			self.speechPitch(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechPitch());
 			self.speechRate(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechRate());
 			self.speechLanguage(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.speechLanguage());
+			self.useCustomGCODE(self.settingsViewModel.settings.plugins.M117SpeechSynthesis.useCustomGCODE());
 		}
 			
 		self.testVoice = function(data) {

--- a/octoprint_M117SpeechSynthesis/templates/M117SpeechSynthesis_settings.jinja2
+++ b/octoprint_M117SpeechSynthesis/templates/M117SpeechSynthesis_settings.jinja2
@@ -81,5 +81,11 @@
 				<button class="btn btn-primary" data-bind="click: testVoice,enable: settingsViewModel.settings.plugins.M117SpeechSynthesis.speechVoice() !== ''">Test</button>
 			</div>
 		</div>
+		<div class="control-group">
+			<label class="control-label">{{ _('Use Custom GCODE @SPEAK') }}</label>
+			<div class="controls">
+				<input type="checkbox" data-bind="checked: settingsViewModel.settings.plugins.M117SpeechSynthesis.useCustomGCODE">
+			</div>
+		</div>
 	</div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-M117SpeechSynthesis"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.4.0"
+plugin_version = "0.5.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- Added option for using custom GCODE commands.  When enabled in settings processing of regular M117 messages will stop working. Use the command @SPEAK as replacement to M117.